### PR TITLE
rename path to URL strings

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,17 +152,19 @@
 	
 					<p>The contents of both files are specified in [[wpub]]; they MUST not be encrypted.</p>
 
-					<p>A Package MUST also include all resources within the bounds of the Publication, i.e. the finite set of resources obtained from the union of resources listed in the default reading order and resource list of the Publication Manifest.</p>
+					<p>A Package MUST also include all resources within the bounds of the Publication, 
+					i.e. the finite set of resources obtained from the union of resources listed 
+					in the default reading order and resource list of the Publication Manifest.</p>
 
 					<p>These resource files MAY be in any location descendant from the Root Directory.</p>
 
-					<p>Files within the Package MUST reference each other via relative paths, resolving to resources 
-						within the Package (i.e. at or below the <a>Root Directory</a>).</p>
+					<p>Files within the Package MUST reference each other via relative URL strings [url], 
+					resolving to resources within the Package (i.e. at or below the <a>Root Directory</a>).</p>
 		
 					<div class="note">
 							<p>The [[zip]] specification has few constraints on the characters allowed for file and directory names. 
 								When crafting such names, authors must be careful to use characters which 
-								allow a broad interoperability among operating systems and are compatible with relative paths.</p>
+								allow a broad interoperability among operating systems.</p>
 					</div>
 	
 			</section>
@@ -231,9 +233,9 @@
 								</details>
 						</li>
 						<li>Otherwise: <ol>
-								<li>Let <var>manifest path</var> be the value of the <code>href</code> attribute. </li>
-								<li>If <var>manifest path</var> is not a relative path, then abort these steps. </li>
-								<li>Extract the Manifest from the Package using <var>manifest path</var>. </li>
+								<li>Let <var>manifest URL</var> be the value of the <code>href</code> attribute. </li>
+								<li>If <var>manifest URL</var> is not a relative URL string, then abort these steps. </li>
+								<li>Extract the Manifest from the Package using <var>manifest URL</var>. </li>
 								<li>Open and read the Manifest file, letting <var>text</var> be the result. </li>
 							</ol>
 							<details>

--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
 
 					<p>These resource files MAY be in any location descendant from the Root Directory.</p>
 
-					<p>Files within the Package MUST reference each other via relative URL strings [url], 
+					<p>Files within the Package MUST reference each other via relative URL strings [[!url]], 
 					resolving to resources within the Package (i.e. at or below the <a>Root Directory</a>).</p>
 		
 					<div class="note">


### PR DESCRIPTION
We currently state that "Files within the Package MUST reference each other via relative paths, resolving to resources within the Package".

This is not exact, as the Publication Manifest specifies that the `url` property in a link is a "URL string", refering to the WHATWG URL spec.

The proposal is mainly to change the wording for "Files within the Package MUST reference each other via relative URL strings [url], resolving to resources within the Package". This implies that the URL string (with % encoded spaces and all) is transformed to a classical *path*  when reaching files inside the zip archive. This is something the WHATWG URL definition complies with (a URL can correspond to a file path).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/lpf/pull/1.html" title="Last updated on Aug 22, 2019, 4:35 PM UTC (4dcbad8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/lpf/1/fdea739...4dcbad8.html" title="Last updated on Aug 22, 2019, 4:35 PM UTC (4dcbad8)">Diff</a>