### PR TITLE
sync with Pub Manifest vocabulary

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
 					<dd>
 						<p>The primary entry page represents the preferred starting resource for a <a>Web Publication</a>.  The structure of a Primary Entry Page is defined in [[wpub]].</p>
 					</dd>
-					<dt><dfn id="dfn-publication" data-lt="Publications">Publication</dfn></dt>
+					<dt><dfn id="dfn-publication" data-lt="Publications">Digital Publication</dfn></dt>
 					<dd>
 						<p>A digital Publication is a collection of one or more constituent resources and associated metadata, organized together in a uniquely identifiable grouping.</p>
 					</dd>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: write EPROTO 139705468127104:error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/s23_clnt.c:772:
 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 12, 2020, 11:42 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Flpf%2Fpull%2F17%2F4dcbad8.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Flpf%2Fpull%2F17.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/lpf%2317.)._
</details>
